### PR TITLE
Feature: Plugin Metadata in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 
 ## TODO
 
-* Register Events the same as Middleware
-	* ?? Semaphore should gate so they can't be registered later 
-* Show Plugin Metadata in Settings
-	* Name
-	* Version (needs added to Plugin Interface)
-	* Priority (if one)
-	* Middleware Chains
-	* Events Listening (get from registration)
-	* Events Emitted (atm looks to need explicit listing)
-	* Needs style that looks good/different, but understandable
-		* Mouse events disabled?
 * Need new custom error type: `ForceShowUser`
   * Enforces calling `showError` so the user can see
   * Discretionary use, specifically for when plugins/chains/etc simply CANNOT work and it breaks the entire everything. IE, user auth fails at some point?
@@ -61,10 +50,6 @@
 * Build a dropdown to jump to a plugins' settings
   * Plugin will need more contextual data:
     * Name
-* Event Sub Response:
-  * Output simple message (customizable) indicating an event was triggered
-  * Needs a tokenized mapping of event sub properties
-    * https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainbegin
 * Convert to use `hh-util`
   * `hh-util` needs proper publishing
   * `hh-util` needs proper lifecycle support
@@ -106,6 +91,10 @@
 
 * Chat Core
 * EventSub Core
+* Event Sub Response:
+  * Output simple message (customizable) indicating an event was triggered
+  * Needs a tokenized mapping of event sub properties
+    * https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelhype_trainbegin
 * OBS WS Core
 * Chat Animations
   * https://www.minimamente.com/project/magic/
@@ -128,80 +117,15 @@
   * VIP/Mod/etc get style treatments?
   * This is basically a theme with minimal purpose
   * Might have multiple versions of this theme
-* Ad Detection
-  * Sends Message
-  * Needs Auth
 * Top Chatter
   * Special Badge?
   * Some kind of color/etc treatment
+* Ad Detection
+  * Sends Message
+  * Needs Auth
 * Follower Stuff
   * Border/glow animations?
   * Confetti around follow message in chat?
   * Send message welcoming viewer
 * History Plugin:
   * Stores chats in localStorage to be retrieved on load, so chat isn't empty on first load
-
-
-
-### Tree Code
-
-No clue what this was for???
-
-```js
-function TreeNode(value) {
-  this.value = value;
-  this.left = null;
-  this.right = null;
-}
-
-function constructBinaryTree(sortedArray, start, end) {
-  if (start > end) {
-    return null;
-  }
-
-  const middle = Math.floor((start + end) / 2);
-  const node = new TreeNode(sortedArray[middle]);
-
-  node.left = constructBinaryTree(sortedArray, start, middle - 1);
-  node.right = constructBinaryTree(sortedArray, middle + 1, end);
-
-  return node;
-}
-
-function findNode(root, value) {
-  if (root === null || root.value === value) {
-    return root;
-  }
-
-  // Recursively search in the left subtree
-  const leftResult = findNode(root.left, value);
-  if (leftResult !== null) {
-    return leftResult;
-  }
-
-  // Recursively search in the right subtree
-  const rightResult = findNode(root.right, value);
-  if (rightResult !== null) {
-    return rightResult;
-  }
-
-  return null; // Node not found
-}
-
-// Example usage
-const array = ['apple', 'banana', 'cherry', 'date', 'elderberry'];
-const sortedArray = array.sort();
-
-const binaryTree = constructBinaryTree(sortedArray, 0, sortedArray.length - 1);
-console.log(binaryTree);
-
-const nodeToFind = 'banana';
-const foundNode = findNode(binaryTree, nodeToFind);
-
-if (foundNode !== null) {
-  console.log(`Node '${nodeToFind}' found in the binary tree.`);
-} else {
-  console.log(`Node '${nodeToFind}' not found in the binary tree.`);
-}
-
-```

--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 ## TODO
 
+* Register Events the same as Middleware
+	* ?? Semaphore should gate so they can't be registered later 
+* Show Plugin Metadata in Settings
+	* Name
+	* Version (needs added to Plugin Interface)
+	* Priority (if one)
+	* Middleware Chains
+	* Events Listening (get from registration)
+	* Events Emitted (atm looks to need explicit listing)
+	* Needs style that looks good/different, but understandable
+		* Mouse events disabled?
 * Need new custom error type: `ForceShowUser`
   * Enforces calling `showError` so the user can see
   * Discretionary use, specifically for when plugins/chains/etc simply CANNOT work and it breaks the entire everything. IE, user auth fails at some point?
-* Move existing Twitch Chat stuff over to it's own Chat: Core plugin
-  * Include Authentication w/Twitch
-    * Look more into: https://twitchtokengenerator.com/
-  * Needs refresh capabilities
-  * Event:SendMessage (if auth'd properly) - Sends a simple message to chat
-  * Event:HasAuth - ?? returns bool if auth'd
 * Figure out debouncing on Settings... There's some annoyance with UX and jumping to a required input
 * Bootstrapper should load HTML Template file
 * Handle error responses from `SettingsValidator`
@@ -21,6 +26,12 @@
 * Add Reset capability
   * Delete localStorage
   * Wipe URI params and reload page
+* Move existing Twitch Chat stuff over to it's own Chat: Core plugin
+  * Include Authentication w/Twitch
+    * Look more into: https://twitchtokengenerator.com/
+  * Needs refresh capabilities
+  * Event:SendMessage (if auth'd properly) - Sends a simple message to chat
+  * Event:HasAuth - ?? returns bool if auth'd
 * Find and Fix all `TODO` and `FIXME` comments in entire source!
   * Do not leave any! Finish ALL of them at once!
   * Add missing HTMLInput Elements:

--- a/src/scripts/OverlayBootstrapper.ts
+++ b/src/scripts/OverlayBootstrapper.ts
@@ -24,6 +24,7 @@ export class OverlayBootstrapper<OS extends PluginSettingsBase> implements Error
 
       pluginRegistrar: {
         registerMiddleware: this.busManager.registerMiddleware,
+        registerEvents: this.busManager.registerEvents,
         registerSettings: this.settingsManager.registerSettings,
         registerStylesheet: AddStylesheet
       },
@@ -91,6 +92,7 @@ export class OverlayBootstrapper<OS extends PluginSettingsBase> implements Error
   private bindManagerEvents() {
     this.pluginManager.addListener(PluginManagerEvents.LOADED, () => {
       this.settingsManager.updateParsedJsonResults();
+      this.busManager.disableAddingListeners();
     });
 
     this.pluginManager.addListener(PluginManagerEvents.UNLOADED, () => {

--- a/src/scripts/Plugin_Core.ts
+++ b/src/scripts/Plugin_Core.ts
@@ -55,7 +55,7 @@ export default class Plugin_Core<OS extends OverlaySettings_Chat> implements Plu
   constructor(public options: PluginOptions<OS>) {}
 
   getRegistrationOptions = (): PluginRegistrationOptions => ({
-    middlewarePipelines: this._getMiddleware(),
+    middlewares: this._getMiddleware(),
     //TODO Move to Twitch Chat Plugin
     settings: this._getSettings()
   });

--- a/src/scripts/managers/PluginManager.ts
+++ b/src/scripts/managers/PluginManager.ts
@@ -227,9 +227,9 @@ export class PluginManager<OS extends PluginSettingsBase> extends EventEmitter i
         importResults.bad.push(new Error(`Could not inject Settings Schema for Plugin: ${plugin.name}`));
       }
 
-      // Register Middleware Pipelines from Plugins
+      // Register Middleware Chains from Plugins
       try {
-        pluginRegistrar.registerMiddleware(plugin, registration.middlewarePipelines);
+        pluginRegistrar.registerMiddleware(plugin, registration.middlewares);
       } catch (err) {
         importResults.bad.push(new Error(`Could not Register Middleware for Plugin: ${plugin.name}`));
       }

--- a/src/scripts/types/Plugin.ts
+++ b/src/scripts/types/Plugin.ts
@@ -1,3 +1,4 @@
+import { Listener } from 'events';
 import { FormEntryGrouping } from '../utils/Forms.js';
 import { BusManagerEmitter, RenderOptions, SettingsValidatorResults } from './Managers.js';
 import { PluginMiddlewareMap } from './Middleware.js';
@@ -11,11 +12,10 @@ export type PluginImportResults<OS extends PluginSettingsBase> = {
 
 export type PluginRegistrar<OS extends PluginSettingsBase> = {
   registerMiddleware(plugin: PluginInstance<OS>, queriedMiddleware: PluginMiddlewareMap | undefined): void;
+  registerEvents(plugin: PluginInstance<OS>, eventMap?: PluginEventMap): void;
   registerSettings(fieldGroup?: FormEntryGrouping | undefined): void;
   registerStylesheet: (href: string) => void;
 };
-
-// Overlay Instance
 
 export type PluginSettingsBase = {
   forceShowSettings?: boolean;
@@ -23,15 +23,23 @@ export type PluginSettingsBase = {
   customPlugins?: string[];
 };
 
+export type PluginEventMap = Record<string, Listener>;
+
+export type PluginEventRegistration = {
+  receives?: PluginEventMap;
+  sends?: string[];
+};
+
 export type PluginRegistrationOptions = {
   middlewares?: PluginMiddlewareMap;
+  events?: PluginEventRegistration;
   settings?: FormEntryGrouping;
   stylesheet?: URL;
 };
 
 export type PluginOptions<OS extends PluginSettingsBase> = {
   getSettings: () => OS;
-  emitter: BusManagerEmitter;
+  emitter: Readonly<BusManagerEmitter>;
   renderOptions: RenderOptions;
 };
 
@@ -45,6 +53,7 @@ export type PluginInstance<OS extends PluginSettingsBase> = {
 
   // Plugin should define these
   name: string;
+  version: string;
   ref: Symbol;
   priority?: number;
 

--- a/src/scripts/types/Plugin.ts
+++ b/src/scripts/types/Plugin.ts
@@ -24,7 +24,7 @@ export type PluginSettingsBase = {
 };
 
 export type PluginRegistrationOptions = {
-  middlewarePipelines?: PluginMiddlewareMap;
+  middlewares?: PluginMiddlewareMap;
   settings?: FormEntryGrouping;
   stylesheet?: URL;
 };

--- a/src/scripts/utils/EnhancedEventEmitter.ts
+++ b/src/scripts/utils/EnhancedEventEmitter.ts
@@ -1,10 +1,16 @@
 import { EventEmitter, Listener } from 'events';
 
 export class EnhancedEventEmitter extends EventEmitter {
-  _storeListenersMap: Record<string, [Listener, Listener][]> = {};
-  _storeValuesMap: Record<string, [Listener, any][]> = {};
+  disableAddingListeners = false;
+
+  private _storeListenersMap: Record<string, [Listener, Listener][]> = {};
+  private _storeValuesMap: Record<string, [Listener, any][]> = {};
 
   override addListener = (type: string | number, listener: Listener): this => {
+    if (true === this.disableAddingListeners) {
+      throw new Error('The EventEmitter is marked as disallowing adding new Listeners!');
+    }
+
     const newListener = (...args: any[]) => {
       this._storeValuesMap[type] = this._storeValuesMap[type] ?? [];
       const val = listener.apply(listener, args);
@@ -71,8 +77,11 @@ export class EnhancedEventEmitter extends EventEmitter {
     if (type) {
       delete this._storeValuesMap[type];
       delete this._storeListenersMap[type];
+    } else {
+      this._storeValuesMap = {};
+      this._storeListenersMap = {};
     }
 
-    return super.removeAllListeners(type);
+    return super.removeAllListeners();
   }
 }

--- a/src/scripts/utils/Forms.ts
+++ b/src/scripts/utils/Forms.ts
@@ -66,8 +66,8 @@ export const FromJson = <Settings extends {}>(
     const defaultData = (isButton && entry.defaultValue) ?? '';
     const required = isButton && entry.isRequired ? 'required' : '';
     const tooltip = isButton && entry.tooltip ? `title="${entry.tooltip}"` : '';
-    const uniqueId = `${entry.name}-${labelId++}`; // unique ID for labels
-    const nameOrLabelId = entry.name ?? entry.label?.toLocaleLowerCase().replaceAll(' ', '_');
+    const nameOrLabelId = (entry.name ?? entry.label)?.toLocaleLowerCase().replaceAll(' ', '_');
+    const uniqueId = `${nameOrLabelId}-${labelId++}`; // unique ID for labels
 
     let inputType = '';
     let recursedCall: ParsedJsonResults | undefined;
@@ -362,16 +362,26 @@ export const Populate = (form: HTMLFormElement, formData: FormData) => {
         const enabledIndices = (currValue as string[]).map(v => v.split(':')[0]);
         opts.forEach((opt, idx) => (opt.selected = enabledIndices.includes(idx.toString())));
       } else if (element instanceof RadioNodeList) {
-        const inputs = [...element.values()];
-        // `value` is a comma-separated string of selected indices
-        const enabledIndices = (currValue as string[]).map(v => v.split(':')[0]);
-        inputs.forEach((input, idx) => {
-          if (input instanceof HTMLInputElement) {
-            input.checked = enabledIndices.includes(idx.toString());
-          } else {
-            console.error(`Invalid Input Type: ${input}`);
+        try {
+          const inputs = [...element.values()];
+          // `value` is a comma-separated string of selected indices
+          const enabledIndices = (currValue as string[]).map(v => v.split(':')[0]);
+          inputs.forEach((input, idx) => {
+            if (input instanceof HTMLInputElement) {
+              input.checked = enabledIndices.includes(idx.toString());
+            } else {
+              console.error(`Invalid Input Type: ${input}`);
+            }
+          });
+        } catch (err) {
+          if (false === err instanceof Error) {
+            return;
           }
-        });
+
+          throw new Error(
+            'Supplied a single value where a list was expected. If this is unintentional, be sure to use unique names for your fields'
+          );
+        }
       }
     }
   }

--- a/src/scripts/utils/Middleware.ts
+++ b/src/scripts/utils/Middleware.ts
@@ -9,26 +9,25 @@ export type Middleware<Context extends {}> = (
 ) => Promise<void> | void;
 
 /**
- * Declare a new middleware Pipeline.
+ * Declare a new middleware Chain.
  */
-export class Pipeline<Context extends {}> {
+export class MiddlewareChain<Context extends {}> {
   /**
-   * @param stack A list of middlewares to add to the pipeline on instantiation.
+   * @param stack A list of middlewares to add to the Chain on instantiation.
    */
   constructor(protected stack: Middleware<Context>[] = []) {}
 
   /**
-   * Add middlewares to the pipeline.
-   * @param middlewares A list of middlewares to add to the current
-   * pipeline.
+   * Add middlewares to the Chain.
+   * @param middlewares A list of middlewares to add to the current Chain.
    */
   use(...middlewares: Middleware<Context>[]) {
     this.stack.push(...middlewares);
   }
 
   /**
-   * Execute a pipeline, and move context through each middleware in turn.
-   * @param context The contect object to be sent through the pipeline.
+   * Execute a Chain, and move context through each middleware in turn.
+   * @param context The contect object to be sent through the Chain.
    */
   async execute(ctx: Context) {
     return await this.executeMiddleware(ctx, this.stack);
@@ -40,7 +39,7 @@ export class Pipeline<Context extends {}> {
     // If an error is detected, skip to the end and attempt to handle the error before it throws.
     const slice: Middleware<Context> = error ? middlewares[middlewares.length - 1] : middlewares[0];
 
-    // If an error is detected, give the opportunity to continue the chain after testing error,
+    // If an error is detected, give the opportunity to continue the Chain after testing error,
     // otherwise skip to the next (and remainder of) list.
     const nextMiddlewares = error ? middlewares : middlewares.slice(1);
 

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -162,6 +162,40 @@
     label {
       display: inline-block;
     }
+
+    // Plugin Metadata
+    & > details:not(:first-child) .content > details:last-child {
+      margin: 0;
+      font-size: 0.7em;
+
+      [data-input-type] {
+        flex-direction: row;
+      }
+
+      input:not([type='checkbox'], [type='radio']),
+      select,
+      textarea {
+        width: auto;
+        font-size: 1em;
+      }
+
+      .label-wrapper {
+        padding-left: 0;
+      }
+
+      label {
+        min-width: 10rem;
+        margin: 0;
+      }
+
+      input {
+        background: none;
+        border: none;
+        height: auto;
+        padding: 0;
+        margin: 0;
+      }
+    }
   }
 
   .link-results {

--- a/static/plugins/Example/plugin.js
+++ b/static/plugins/Example/plugin.js
@@ -38,7 +38,7 @@ export default class Plugin_Example {
    */
   getRegistrationOptions = () => ({
     settings: this._getSettings(),
-    middlewarePipelines: this._getMiddleware(),
+    middlewares: this._getMiddleware(),
     stylesheet: new URL(`${import.meta.url.split('/').slice(0, -1).join('/')}/plugin.css`)
   });
 
@@ -67,7 +67,7 @@ export default class Plugin_Example {
    * @returns {PluginMiddlewareMap}
    */
   _getMiddleware() {
-    // This should error, since this isn't the first plugin to register the chain pipeline
+    // This should error, since this isn't the first plugin to register the chain
     setTimeout(() => {
       /** @type {BusManagerContext_Init} */
       const ctx = {
@@ -123,12 +123,12 @@ export default class Plugin_Example {
     console.log('[MW 1] - Start');
 
     if (context.message?.includes('skipCurrent')) {
-      console.log('[MW 1] - Skipping the rest of current Segment, move onto the next one');
+      console.log('[MW 1] - Skipping the rest of current Link, move onto the next one');
       await next();
       return;
     }
 
-    console.log('[MW 1] - Not skipping the current Segment, mutate and continue');
+    console.log('[MW 1] - Not skipping the current Link, mutate and continue');
 
     context.message += ' [MW 1 Exec] ';
 
@@ -149,7 +149,7 @@ export default class Plugin_Example {
 
     if (context.message?.includes('skipChain1')) {
       console.log('[MW 2] - Next - Skipping the rest of Chain');
-      await next(new Error('', { cause: { forceFailPipeline: true } }));
+      await next(new Error('', { cause: { forceFailChain: true } }));
       return;
     }
 
@@ -174,7 +174,7 @@ export default class Plugin_Example {
 
     if (context.message?.includes('skipChain2')) {
       console.log('[MW 3] - Error - [Incorrectly] Skipping the rest of Chain');
-      throw new Error('', { cause: { forceFailPipeline: true } });
+      throw new Error('', { cause: { forceFailChain: true } });
     }
 
     console.log('[MW 3] - Error - Not skipping the rest of Chain, mutate and continue');
@@ -209,7 +209,7 @@ export default class Plugin_Example {
     console.log('[MW 5] - Next Error');
 
     if (context.message?.includes('nextError')) {
-      console.log('[MW 5] - Next Error - Skipping the rest of Segment');
+      console.log('[MW 5] - Next Error - Skipping the rest of Link');
       await next(new Error('Not Skippable Error'));
       return;
     }
@@ -233,7 +233,7 @@ export default class Plugin_Example {
     console.log('[MW 6] - Throw Error');
 
     if (context.message?.includes('throwError')) {
-      console.log('[MW 6] - Throw Error - Skipping the rest of Segment');
+      console.log('[MW 6] - Throw Error - Skipping the rest of Link');
       throw new Error('Not Skippable Error');
     }
 

--- a/static/plugins/HangoutHere/plugin.js
+++ b/static/plugins/HangoutHere/plugin.js
@@ -12,6 +12,7 @@
  * @typedef {import('../../../src/scripts/types/Managers.js').BusManagerContext_Init<ContextBase>} BusManagerContext_Init
  * @typedef {import('../../../src/scripts/types/Middleware.js').ContextBase} ContextBase
  * @typedef {import('../../../src/scripts/types/Middleware.js').PluginMiddlewareMap} PluginMiddlewareMap
+ * @typedef {import('../../../src/scripts/types/Plugin.js').PluginEventRegistration} PluginEventMap
  * @typedef {import('../../../src/scripts/types/Plugin.js').PluginOptions<OS>} PluginInjectables
  * @typedef {import('../../../src/scripts/types/Plugin.js').PluginInstance<OS>} PluginInstance
  * @typedef {import('../../../src/scripts/types/Plugin.js').PluginRegistrationOptions} PluginRegistrationOptions
@@ -21,6 +22,7 @@
  */
 export default class Plugin_HangoutHereTheme {
   name = 'HangoutHere Theme';
+  version = '1.0.0';
   ref = Symbol(this.name);
 
   /**
@@ -30,16 +32,15 @@ export default class Plugin_HangoutHereTheme {
     this.options = options;
 
     console.log(`${this.name} instantiated`);
-
-    this.options.emitter.addListener('test-event', this.testEventHandler);
   }
 
   /**
    * @returns {PluginRegistrationOptions}
    */
-  getRegistrationOptions = () => ({
+  registerPlugin = () => ({
     settings: this._getSettings(),
     middlewares: this._getMiddleware(),
+    events: this._getEvents(),
     stylesheet: new URL(`${import.meta.url.split('/').slice(0, -1).join('/')}/plugin.css`)
   });
 
@@ -94,9 +95,22 @@ export default class Plugin_HangoutHereTheme {
     'chat:twitch': [this.middleware]
   });
 
+  /**
+   * @returns {PluginEventMap}
+   */
+  _getEvents() {
+    console.log(`[${this.name}] Registering Events`);
+
+    return {
+      receives: {
+        'test-event': this.testEventHandler
+      },
+      sends: ['chat:twitch--send']
+    };
+  }
+
   unregisterPlugin() {
     console.log(`${this.name} Unregistering`);
-    this.options.emitter.removeListener('test-event', this.testEventHandler);
   }
 
   renderSettings() {

--- a/static/plugins/HangoutHere/plugin.js
+++ b/static/plugins/HangoutHere/plugin.js
@@ -39,7 +39,7 @@ export default class Plugin_HangoutHereTheme {
    */
   getRegistrationOptions = () => ({
     settings: this._getSettings(),
-    middlewarePipelines: this._getMiddleware(),
+    middlewares: this._getMiddleware(),
     stylesheet: new URL(`${import.meta.url.split('/').slice(0, -1).join('/')}/plugin.css`)
   });
 


### PR DESCRIPTION
* Renamed Pipeline->Chain, and Segment->Link to better represent Middleware Chain nomenclature
* Bugfix: Fixed removeAllListeners, was passing in `undefined`, but the  code checks for `arguments.length == 0` which wasn't hitting when passed in.
* Added `registerEvents` to `PluginRegistrationOptions`
* Added `version` to `PluginInstance` for metadata output
* Updated all Plugins to include `events` in `registerPlugin`
* Events are now added in the PluginManager
* PluginManager now injects a `fieldgroup` with Plugin Metadata
* CSS: Styles targeting Plugin Metadata for minified view
* BusManagerEmitter now has the ability to lockdown adding new events
* Forms now can handle detecting invalid naming convention by way of populating. When it detects a RadioNodeList but only gets a single input value, we Error and tell the user to check for unique field names.